### PR TITLE
Fix for #20 - Add Support for CLI options

### DIFF
--- a/plugin/src/main/scala/templemore/sbt/cucumber/Integration.scala
+++ b/plugin/src/main/scala/templemore/sbt/cucumber/Integration.scala
@@ -33,6 +33,25 @@ trait Integration {
     }
   }
 
+  /*
+   * The options that are supported by the plugin.
+   * This excludes options that are set in other places such as formatting
+   * and dotcucumber etc.
+   *
+   * This is essentially a list of the parameter-less options supported by the
+   * `cucumber-jvm` `cucumber.runtime.RuntimeOptions` class
+   *
+   * The `--no-xxx` version of the options are not included as they are not enabled
+   * by default and are therefore not really necessary.
+   */
+  private val supportedOptions = Seq("-d",
+                                     "--dry-run",
+                                     "-s",
+                                     "--strict",
+                                     "-m",
+                                     "--monochrome")
+
+
   private def runCucumber(args: Seq[String],
                           jvmSettings: JvmSettings,
                           options: Options,
@@ -42,9 +61,7 @@ trait Integration {
     def optsFromArgs = args.filter(isAnOption).toList
     def namesFromArgs = args.filter(isAName).toList
 
-    val optionPattern = """-[a-z]""".r.pattern
-
-    def isAnOption(arg: String) = (arg.startsWith("--") || optionPattern.matcher(arg).matches())
+    def isAnOption(arg: String) = supportedOptions.contains(arg)
     def isATag(arg: String) = arg.startsWith("@") || arg.startsWith("~@")
     def isAName(arg:String) = !isATag(arg) && !isAnOption(arg)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,9 +1,11 @@
 import sbt._
 import Keys._
 
+import Versions._
+
 object Settings {
   val buildOrganization = "templemore"
-  val buildScalaVersion = "2.9.2"
+  val buildScalaVersion = scala2_9
   val buildVersion      = "0.7.2"
 
   val buildSettings = Defaults.defaultSettings ++
@@ -15,9 +17,6 @@ object Settings {
 }
 
 object Dependencies {
-
-  private val CucumberVersionForScala2_9 = "1.0.9"
-  private val CucumberVersionForScala2_10 = "1.1.1"
 
   def cucumberScala(scalaVersion: String) = {
     def cucumberVersion = if ( scalaVersion.startsWith("2.10") ) CucumberVersionForScala2_10 else CucumberVersionForScala2_9
@@ -32,9 +31,11 @@ object Build extends Build {
   import Dependencies._
   import Settings._
 
+  private val crossVersions = Seq(scala2_9, scala2_10)
+
   lazy val parentProject = Project("sbt-cucumber-parent", file ("."),
     settings = buildSettings ++
-               Seq(crossScalaVersions := Seq("2.9.2", "2.10.0-RC2"))) aggregate (pluginProject, integrationProject)
+               Seq(crossScalaVersions := crossVersions)) aggregate (pluginProject, integrationProject)
 
   lazy val pluginProject = Project("sbt-cucumber-plugin", file ("plugin"),
     settings = buildSettings ++ 
@@ -42,8 +43,15 @@ object Build extends Build {
 
   lazy val integrationProject = Project ("sbt-cucumber-integration", file ("integration"),
     settings = buildSettings ++ 
-               Seq(crossScalaVersions := Seq("2.9.2", "2.10.0-RC2"),
+               Seq(crossScalaVersions := crossVersions,
                    libraryDependencies <+= scalaVersion { sv => cucumberScala(sv) },
                    libraryDependencies += testInterface))
 }
 
+
+object Versions {
+  val scala2_9 = "2.9.2"
+  val scala2_10 = "2.10.0"
+  val CucumberVersionForScala2_9 = "1.0.9"
+  val CucumberVersionForScala2_10 = "1.1.1"
+}


### PR DESCRIPTION
A simple fix to extract additional command line options from the arguments passed to the `cucumber` task that are not already handled by the plugin.

Adds support for:
- `--dry-run`, `-d`
- `--strict`, `-s`
- `--monochrone`, `-m`

Also updated version for Scala 2.10 to the 2.10.0 final from the RC2
