### PR TITLE
Updating to cucumber-jvm 1.1.8 and cross-building for Scala 2.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ target
 project/boot
 project/target
 .idea/workspace.xml
+.idea
+.idea_modules
 .ensime_port
 xsbt-cucumber-plugin.sublime-workspace
 deploy-repo

--- a/plugin/src/main/scala/templemore/sbt/cucumber/CucumberPlugin.scala
+++ b/plugin/src/main/scala/templemore/sbt/cucumber/CucumberPlugin.scala
@@ -10,7 +10,7 @@ import templemore.sbt.util._
  */
 object CucumberPlugin extends Plugin with Integration {
 
-  private val projectVersion = "0.8.0"
+  private val projectVersion = "0.9.0-SNAPSHOT"
 
   type LifecycleCallback = () => Unit
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,9 +3,9 @@ import Keys._
 
 object Settings {
   val buildOrganization = "templemore"
-  val buildScalaVersion = "2.10.2"
-  val crossBuildScalaVersions = Seq("2.9.3", "2.10.2")
-  val buildVersion      = "0.8.0"
+  val buildScalaVersion = "2.10.4"
+  val crossBuildScalaVersions = Seq("2.10.4", "2.11.2")
+  val buildVersion      = "0.9.0-SNAPSHOT"
 
   val buildSettings = Defaults.defaultSettings ++
                       Seq (organization  := buildOrganization,
@@ -17,7 +17,7 @@ object Settings {
 
 object Dependencies {
 
-  private val CucumberVersion = "1.1.4"
+  private val CucumberVersion = "1.1.8"
 
   def cucumberJvm(scalaVersion: String) = 
     if ( scalaVersion.startsWith("2.9") ) "info.cukes" % "cucumber-scala_2.9" % CucumberVersion % "compile"
@@ -31,7 +31,7 @@ object Build extends Build {
   import Settings._
 
   lazy val parentProject = Project("sbt-cucumber-parent", file ("."),
-    settings = buildSettings)
+    settings = buildSettings).aggregate(pluginProject, integrationProject)
 
   lazy val pluginProject = Project("sbt-cucumber-plugin", file ("plugin"),
     settings = buildSettings ++

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,11 +17,10 @@ object Settings {
 
 object Dependencies {
 
-  private val CucumberVersion = "1.1.8"
+  private val CucumberVersion = "1.2.0-SNAPSHOT"
 
-  def cucumberJvm(scalaVersion: String) = 
-    if ( scalaVersion.startsWith("2.9") ) "info.cukes" % "cucumber-scala_2.9" % CucumberVersion % "compile"
-    else "info.cukes" %% "cucumber-scala" % CucumberVersion % "compile"
+  def cucumberJvm(scalaVersion: String) =
+    "info.cukes" %% "cucumber-scala" % CucumberVersion % "compile"
 
   val testInterface = "org.scala-tools.testing" % "test-interface" % "0.5" % "compile"
 }
@@ -38,8 +37,9 @@ object Build extends Build {
                Seq(crossScalaVersions := Seq.empty, sbtPlugin := true))
 
   lazy val integrationProject = Project ("sbt-cucumber-integration", file ("integration"),
-    settings = buildSettings ++ 
+    settings = buildSettings ++
                Seq(crossScalaVersions := crossBuildScalaVersions,
+               resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
                libraryDependencies <+= scalaVersion { sv => cucumberJvm(sv) },
                libraryDependencies += testInterface))
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,7 @@ object Settings {
 
 object Dependencies {
 
-  private val CucumberVersion = "1.2.0-SNAPSHOT"
+  private val CucumberVersion = "1.2.0"
 
   def cucumberJvm(scalaVersion: String) =
     "info.cukes" %% "cucumber-scala" % CucumberVersion % "compile"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,7 +3,7 @@ import Keys._
 
 object Settings {
   val buildOrganization = "templemore"
-  val buildScalaVersion = "2.10.4"
+  val buildScalaVersion = "2.11.2"
   val crossBuildScalaVersions = Seq("2.10.4", "2.11.2")
   val buildVersion      = "0.9.0-SNAPSHOT"
 
@@ -34,7 +34,10 @@ object Build extends Build {
 
   lazy val pluginProject = Project("sbt-cucumber-plugin", file ("plugin"),
     settings = buildSettings ++
-               Seq(crossScalaVersions := Seq.empty, sbtPlugin := true))
+               Seq(
+                 scalaVersion := "2.10.4",
+                 crossScalaVersions := Seq.empty,
+                 sbtPlugin := true))
 
   lazy val integrationProject = Project ("sbt-cucumber-integration", file ("integration"),
     settings = buildSettings ++

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=0.13.0
-
+sbt.version=0.13.5


### PR DESCRIPTION
This builds drops support for Scala 2.9.2 since support for it has been dropped in cucumber-scala 1.1.7
