### PR TITLE
Fixed plugin installation instructions in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -113,9 +113,9 @@ For example:
     }
 
 ## Project Setup ##
-To install the cucumber plugin, add entries to the build plugins file (project/plugins/build.sbt) as follows:
+To install the cucumber plugin, create the file `project/cucumber.sbt` and declare the plugin dependency:
 
-    resolvers += "Templemore Repository" at "https://templemore.co.uk/repo/"
+    resolvers += "Templemore Repository" at "http://templemore.co.uk/repo"
 
     addSbtPlugin("templemore" % "sbt-cucumber-plugin" % "0.8.0")
 


### PR DESCRIPTION
Being new to sbt, I struggled somewhat to get the plugin to work. It turned out that I had to declare the plugin in `project/cucumber.sbt` instead of `project/plugins/build.sbt`. Maybe this has changed in a newer version of sbt (I'm using 0.13.0).

I updated README.markdown with this information.
