### PR TITLE
Allow to customize the cucumber settings

### DIFF
--- a/plugin/src/main/scala/templemore/sbt/cucumber/CucumberPlugin.scala
+++ b/plugin/src/main/scala/templemore/sbt/cucumber/CucumberPlugin.scala
@@ -50,7 +50,7 @@ object CucumberPlugin extends Plugin with Integration {
 
   protected def cucumberTask(dryRun: Boolean = false) = Def.inputTask({
     val args = Def.spaceDelimited("<args>").parsed
-    val settings = cucumberSettingsTask.value
+    val settings = cucumberTestSettings.value
     val opt = cucumberOptions.value
     val out = cucumberOutput.value
     val s = streams.value


### PR DESCRIPTION
This change allow the users to modify the current test settings, otherwise this taskKey (cucumberTestSettings) is never used and has no value.
